### PR TITLE
Default add options manager

### DIFF
--- a/cmd/gardener-extension-ontap/app/options.go
+++ b/cmd/gardener-extension-ontap/app/options.go
@@ -131,9 +131,6 @@ func (options *Options) run(ctx context.Context) error {
 	}
 	log.Info("added mgr-scheme to installation")
 
-	ctrlConfig := options.ontapOptions.Completed()
-	ctrlConfig.Apply(&controller.DefaultAddOptions.Config)
-
 	options.controllerOptions.Completed().Apply(&controller.DefaultAddOptions.ControllerOptions)
 	options.reconcileOptions.Completed().Apply(&controller.DefaultAddOptions.IgnoreOperationAnnotation)
 	options.heartbeatOptions.Completed().Apply(&heartbeatcontroller.DefaultAddOptions)

--- a/pkg/apis/config/types.go
+++ b/pkg/apis/config/types.go
@@ -12,9 +12,6 @@ import (
 type ControllerConfiguration struct {
 	metav1.TypeMeta
 
-	// ClusterManagementIp is the endpoint where the ontap rest api is accessible, for the seed cluster to connect to in order to create and manage svms
-	ClusterManagementIp string
-
 	// AdminAuthSecretRef references to the secret which contains the auth credentials to connect to the cluster management ip
 	AdminAuthSecretRef string
 

--- a/pkg/apis/config/v1alpha1/types.go
+++ b/pkg/apis/config/v1alpha1/types.go
@@ -11,9 +11,6 @@ import (
 type ControllerConfiguration struct {
 	metav1.TypeMeta `json:",inline"`
 
-	// ClusterManagementIp is the endpoint where the ontap rest api is accessible
-	ClusterManagementIp string `json:"clusterManagementIp,omitempty"`
-
 	// AuthSecretRef references to the secret which contains the auth credentials to connect to the ontap rest api.
 	AdminAuthSecretRef string `json:"adminAuthSecret,omitempty"`
 

--- a/pkg/apis/config/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/config/v1alpha1/zz_generated.conversion.go
@@ -40,7 +40,6 @@ func RegisterConversions(s *runtime.Scheme) error {
 }
 
 func autoConvert_v1alpha1_ControllerConfiguration_To_config_ControllerConfiguration(in *ControllerConfiguration, out *config.ControllerConfiguration, s conversion.Scope) error {
-	out.ClusterManagementIp = in.ClusterManagementIp
 	out.AdminAuthSecretRef = in.AdminAuthSecretRef
 	out.AuthSecretNamespace = in.AuthSecretNamespace
 	out.HealthCheckConfig = (*apisconfig.HealthCheckConfig)(unsafe.Pointer(in.HealthCheckConfig))
@@ -53,7 +52,6 @@ func Convert_v1alpha1_ControllerConfiguration_To_config_ControllerConfiguration(
 }
 
 func autoConvert_config_ControllerConfiguration_To_v1alpha1_ControllerConfiguration(in *config.ControllerConfiguration, out *ControllerConfiguration, s conversion.Scope) error {
-	out.ClusterManagementIp = in.ClusterManagementIp
 	out.AdminAuthSecretRef = in.AdminAuthSecretRef
 	out.AuthSecretNamespace = in.AuthSecretNamespace
 	out.HealthCheckConfig = (*configv1alpha1.HealthCheckConfig)(unsafe.Pointer(in.HealthCheckConfig))

--- a/pkg/controller/ontap/actuator.go
+++ b/pkg/controller/ontap/actuator.go
@@ -293,25 +293,31 @@ func (a *actuator) Reconcile(ctx context.Context, log logr.Logger, ex *extension
 
 // Delete the Extension resource.
 func (a *actuator) Delete(ctx context.Context, log logr.Logger, ex *extensionsv1alpha1.Extension) error {
-	// if err := managedresources.Delete(ctx, a.client, ex.Namespace, tridentBackendsMR, false); err != nil {
-	// 	return err
-	// }
-	// if err := managedresources.WaitUntilDeleted(ctx, a.client, ex.Namespace, tridentBackendsMR); err != nil {
-	// 	return err
-	// }
-	// if err := managedresources.Delete(ctx, a.client, ex.Namespace, tridentRbacMR, false); err != nil {
-	// 	return err
-	// }
-	// if err := managedresources.WaitUntilDeleted(ctx, a.client, ex.Namespace, tridentRbacMR); err != nil {
-	// 	return err
-	// }
-	// if err := managedresources.Delete(ctx, a.client, ex.Namespace, tridentCRDsName, false); err != nil {
-	// 	return err
-	// }
-	// if err := managedresources.WaitUntilDeleted(ctx, a.client, ex.Namespace, tridentCRDsName); err != nil {
-	// 	return err
-	// }
-	// log.Info("ManagedResource for Trident operator successfully deleted.")
+	if err := managedresources.Delete(ctx, a.client, ex.Namespace, tridentBackendsMR, false); err != nil {
+		return err
+	}
+	if err := managedresources.WaitUntilDeleted(ctx, a.client, ex.Namespace, tridentBackendsMR); err != nil {
+		return err
+	}
+	if err := managedresources.Delete(ctx, a.client, ex.Namespace, tridentRbacMR, false); err != nil {
+		return err
+	}
+	if err := managedresources.WaitUntilDeleted(ctx, a.client, ex.Namespace, tridentRbacMR); err != nil {
+		return err
+	}
+	if err := managedresources.Delete(ctx, a.client, ex.Namespace, tridentCRDsName, false); err != nil {
+		return err
+	}
+	if err := managedresources.WaitUntilDeleted(ctx, a.client, ex.Namespace, tridentCRDsName); err != nil {
+		return err
+	}
+	if err := managedresources.Delete(ctx, a.client, ex.Namespace, tridentLifServicesMR, false); err != nil {
+		return err
+	}
+	if err := managedresources.WaitUntilDeleted(ctx, a.client, ex.Namespace, tridentLifServicesMR); err != nil {
+		return err
+	}
+	log.Info("ManagedResource for Trident operator successfully deleted.")
 	return nil
 }
 

--- a/pkg/controller/ontap/actuator.go
+++ b/pkg/controller/ontap/actuator.go
@@ -293,31 +293,25 @@ func (a *actuator) Reconcile(ctx context.Context, log logr.Logger, ex *extension
 
 // Delete the Extension resource.
 func (a *actuator) Delete(ctx context.Context, log logr.Logger, ex *extensionsv1alpha1.Extension) error {
-	if err := managedresources.Delete(ctx, a.client, ex.Namespace, tridentBackendsMR, false); err != nil {
-		return err
-	}
-	if err := managedresources.WaitUntilDeleted(ctx, a.client, ex.Namespace, tridentBackendsMR); err != nil {
-		return err
-	}
-	if err := managedresources.Delete(ctx, a.client, ex.Namespace, tridentRbacMR, false); err != nil {
-		return err
-	}
-	if err := managedresources.WaitUntilDeleted(ctx, a.client, ex.Namespace, tridentRbacMR); err != nil {
-		return err
-	}
-	if err := managedresources.Delete(ctx, a.client, ex.Namespace, tridentCRDsName, false); err != nil {
-		return err
-	}
-	if err := managedresources.WaitUntilDeleted(ctx, a.client, ex.Namespace, tridentCRDsName); err != nil {
-		return err
-	}
-	if err := managedresources.Delete(ctx, a.client, ex.Namespace, tridentLifServicesMR, false); err != nil {
-		return err
-	}
-	if err := managedresources.WaitUntilDeleted(ctx, a.client, ex.Namespace, tridentLifServicesMR); err != nil {
-		return err
-	}
-	log.Info("ManagedResource for Trident operator successfully deleted.")
+	// if err := managedresources.Delete(ctx, a.client, ex.Namespace, tridentBackendsMR, false); err != nil {
+	// 	return err
+	// }
+	// if err := managedresources.WaitUntilDeleted(ctx, a.client, ex.Namespace, tridentBackendsMR); err != nil {
+	// 	return err
+	// }
+	// if err := managedresources.Delete(ctx, a.client, ex.Namespace, tridentRbacMR, false); err != nil {
+	// 	return err
+	// }
+	// if err := managedresources.WaitUntilDeleted(ctx, a.client, ex.Namespace, tridentRbacMR); err != nil {
+	// 	return err
+	// }
+	// if err := managedresources.Delete(ctx, a.client, ex.Namespace, tridentCRDsName, false); err != nil {
+	// 	return err
+	// }
+	// if err := managedresources.WaitUntilDeleted(ctx, a.client, ex.Namespace, tridentCRDsName); err != nil {
+	// 	return err
+	// }
+	// log.Info("ManagedResource for Trident operator successfully deleted.")
 	return nil
 }
 

--- a/pkg/controller/ontap/actuator.go
+++ b/pkg/controller/ontap/actuator.go
@@ -69,9 +69,9 @@ func createAdminClient(ctx context.Context, mgr manager.Manager, config config.C
 		return nil, fmt.Errorf("kubernetes client is not initialized")
 	}
 
-	if config.AdminAuthSecretRef == "" || config.ClusterManagementIp == "" || config.AuthSecretNamespace == "" {
-		return nil, fmt.Errorf("missing fields in config: AdminAuthSecretRef=%s, ClusterManagementIp=%s, AuthSecretNamespace=%s",
-			config.AdminAuthSecretRef, config.ClusterManagementIp, config.AuthSecretNamespace)
+	if config.AdminAuthSecretRef == "" || config.AuthSecretNamespace == "" {
+		return nil, fmt.Errorf("missing fields in config: AdminAuthSecretRef=%s, AuthSecretNamespace=%s",
+			config.AdminAuthSecretRef, config.AuthSecretNamespace)
 	}
 
 	var secret corev1.Secret
@@ -90,8 +90,7 @@ func createAdminClient(ctx context.Context, mgr manager.Manager, config config.C
 	}
 	clusterIp, ok := secret.Data["clusterIp"]
 	if !ok {
-		clusterIp = []byte(config.ClusterManagementIp)
-		fmt.Printf("Using clusterIp from config: %s\n", clusterIp)
+		return nil, fmt.Errorf("unable to fetch clusterip from authsecret")
 	}
 
 	log.Info("Connecting to ONTAP using: username=%s, host=%s\n", string(username), string(clusterIp))

--- a/pkg/controller/ontap/add.go
+++ b/pkg/controller/ontap/add.go
@@ -22,7 +22,14 @@ const (
 
 var (
 	// DefaultAddOptions are the default AddOptions for AddToManager.
-	DefaultAddOptions = AddOptions{}
+	DefaultAddOptions = AddOptions{
+
+		Config: config.ControllerConfiguration{
+			ClusterManagementIp: "10.0.0.0",
+			AdminAuthSecretRef:  "admin-access",
+			AuthSecretNamespace: "garden",
+		},
+	}
 )
 var log = runtimelog.Log.WithName("gardener-extension-ontap")
 

--- a/pkg/controller/ontap/add.go
+++ b/pkg/controller/ontap/add.go
@@ -25,7 +25,6 @@ var (
 	DefaultAddOptions = AddOptions{
 
 		Config: config.ControllerConfiguration{
-			ClusterManagementIp: "10.0.0.0",
 			AdminAuthSecretRef:  "admin-access",
 			AuthSecretNamespace: "garden",
 		},


### PR DESCRIPTION
## Description

If no values are set, the following error occurs:

> {"level":"error","ts":"2025-05-13T07:52:22.618Z","msg":"error executing the main controller command","error":"could not add controllers to manager: missing fields in config: AdminAuthSecretRef=, ClusterManagementIp=, AuthSecretNamespace=","stacktrace":"main.main\n\t/go/src/github.com/metal-stack/gardener-extension-ontap/cmd/gardener-extension-ontap/main.go:18\nruntime.main\n\t/usr/local/go/src/runtime/proc.go:283"}


<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
