### PR TITLE
change pause container from busybox to pause

### DIFF
--- a/charts/trident/resources/trident-init/bundle.yaml
+++ b/charts/trident/resources/trident-init/bundle.yaml
@@ -556,8 +556,7 @@ spec:
               mountPropagation: HostToContainer
       containers:
         - name: pause
-          image: busybox:1.36
-          command: ['sleep', '3600']  
+          image: registry.k8s.io/pause:3.10
       volumes:
         - name: modules-dir
           hostPath:


### PR DESCRIPTION
## Description

Currently the ontab-csi-node container gets restarted every hour:

```
NAMESPACE     LAST SEEN   TYPE     REASON       OBJECT                                        MESSAGE
kube-system   43m         Normal   Pulled       pod/ontap-csi-node-7dl2t                      Container image "busybox:1.36" already present on machine
kube-system   43m         Normal   Created      pod/ontap-csi-node-7dl2t                      Created container: pause
kube-system   43m         Normal   Started      pod/ontap-csi-node-7dl2t                      Started container pause
```

We should use a real pause container instead.