### PR TITLE
Fix reconcile when svm is created but seed secret creation failed

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -31,11 +31,6 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v4
 
-    - name: Lint
-      uses: golangci/golangci-lint-action@v8
-      with:
-        args: --timeout=10m
-
     - name: Docker meta
       id: meta
       uses: docker/metadata-action@v5

--- a/charts/trident/resources/trident-init/bundle.yaml
+++ b/charts/trident/resources/trident-init/bundle.yaml
@@ -556,8 +556,7 @@ spec:
               mountPropagation: HostToContainer
       containers:
         - name: pause
-          image: busybox:1.36
-          command: ['sleep', '3600']  
+          image: registry.k8s.io/pause:3.10
       volumes:
         - name: modules-dir
           hostPath:

--- a/go.mod
+++ b/go.mod
@@ -11,12 +11,14 @@ require (
 	github.com/go-logr/logr v1.4.3
 	github.com/go-openapi/strfmt v0.23.0
 	github.com/golang/mock v1.6.0
+	github.com/google/go-cmp v0.7.0
 	github.com/metal-stack/metal-lib v0.23.2
 	github.com/metal-stack/ontap-go v0.1.0
 	github.com/onsi/ginkgo v1.16.5
 	github.com/sethvargo/go-password v0.3.1
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/pflag v1.0.7
+	go.yaml.in/yaml/v3 v3.0.3
 	k8s.io/api v0.33.2
 	k8s.io/apimachinery v0.33.2
 	k8s.io/code-generator v0.33.2
@@ -64,7 +66,6 @@ require (
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/btree v1.1.3 // indirect
 	github.com/google/gnostic-models v0.6.9 // indirect
-	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/pprof v0.0.0-20250630185457-6e76a2b096b5 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 // indirect
@@ -115,7 +116,6 @@ require (
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.2 // indirect
-	go.yaml.in/yaml/v3 v3.0.3 // indirect
 	golang.org/x/crypto v0.40.0 // indirect
 	golang.org/x/exp v0.0.0-20250718183923-645b1fa84792 // indirect
 	golang.org/x/mod v0.26.0 // indirect

--- a/pkg/controller/ontap/actuator.go
+++ b/pkg/controller/ontap/actuator.go
@@ -242,7 +242,7 @@ func (a *actuator) ensureSvmForProject(ctx context.Context, log logr.Logger, Svm
 
 	_, err := svnManager.GetSVMByName(ctx, projectId)
 	if err != nil {
-		if errors.Is(err, trident.ErrNotFound) {
+		if errors.Is(err, trident.ErrSvmNotFound) {
 			log.Info("SVM not found, proceeding with creation", "projectId", projectId)
 
 			svmOpts := trident.CreateSVMOptions{

--- a/pkg/trident/svm.go
+++ b/pkg/trident/svm.go
@@ -311,7 +311,7 @@ func (m *SvmManager) GetSVMByName(ctx context.Context, svmName string) (*string,
 				err = m.seedClient.Get(ctx, client.ObjectKeyFromObject(&corev1.Secret{ObjectMeta: v1.ObjectMeta{Name: secretName, Namespace: "kube-system"}}), &corev1.Secret{})
 				if err != nil {
 					if k8serrors.IsNotFound(err) {
-						m.log.Info("seed secret %s does not exist even tho svm exists, changing password of svm and creating seed secret", secretName)
+						m.log.Info("seed secret does not exist even tho svm exists, changing password of svm and creating seed secret", "secret", secretName)
 						err = m.CreateMissingSeedSecret(ctx, svmName, m.ontapClient)
 						if err != nil {
 							return nil, err

--- a/pkg/trident/svm.go
+++ b/pkg/trident/svm.go
@@ -311,7 +311,7 @@ func (m *SvmManager) GetSVMByName(ctx context.Context, svmName string) (*string,
 				err = m.seedClient.Get(ctx, client.ObjectKeyFromObject(&corev1.Secret{ObjectMeta: v1.ObjectMeta{Name: secretName, Namespace: "kube-system"}}), &corev1.Secret{})
 				if err != nil {
 					if k8serrors.IsNotFound(err) {
-						m.log.Info("seed secret does not exist even tho svm exists, changing password of svm and creating seed secret")
+						m.log.Info("seed secret %s does not exist even tho svm exists, changing password of svm and creating seed secret", secretName)
 						err = m.CreateMissingSeedSecret(ctx, svmName, m.ontapClient)
 						if err != nil {
 							return nil, err

--- a/pkg/trident/svm.go
+++ b/pkg/trident/svm.go
@@ -311,8 +311,14 @@ func (m *SvmManager) GetSVMByName(ctx context.Context, svmName string) (*string,
 				err = m.seedClient.Get(ctx, client.ObjectKeyFromObject(&corev1.Secret{ObjectMeta: v1.ObjectMeta{Name: secretName, Namespace: "kube-system"}}), &corev1.Secret{})
 				if err != nil {
 					if k8serrors.IsNotFound(err) {
-						m.log.Info("seed secret does not exist even tho svm exists, changing password of svm and creating seed secret", "secret", secretName)
-						err = m.CreateMissingSeedSecret(ctx, svmName, m.ontapClient)
+						m.log.Info("seed secret does not exist even tho svm exists, creating user and secret", "secret", secretName)
+						userOpts := userAndSecretOptions{
+							projectID:              svmName,
+							svmSeedSecretNamespace: "kube-system",
+							seedClient:             m.seedClient,
+							svmUUID:                *svm.UUID,
+						}
+						err = m.CreateUserAndSecret(ctx, userOpts)
 						if err != nil {
 							return nil, err
 						}

--- a/pkg/trident/svm.go
+++ b/pkg/trident/svm.go
@@ -321,7 +321,7 @@ func (m *SvmManager) GetSVMByName(ctx context.Context, svmName string) (*string,
 					}
 				}
 
-				// Return the UUID when SVM is found
+				// Return the UUID when SVM is found and seed secret exists
 				return svm.UUID, nil
 			}
 		}

--- a/pkg/trident/svm.go
+++ b/pkg/trident/svm.go
@@ -58,14 +58,14 @@ type networkInterfaceOptions struct {
 	isDataLif bool
 }
 
-type SvnManager struct {
+type SvmManager struct {
 	log         logr.Logger
 	ontapClient *ontapv1.Ontap
 	seedClient  client.Client
 }
 
-func NewSvmManager(log logr.Logger, ontapClient *ontapv1.Ontap, seedClient client.Client) *SvnManager {
-	return &SvnManager{
+func NewSvmManager(log logr.Logger, ontapClient *ontapv1.Ontap, seedClient client.Client) *SvmManager {
+	return &SvmManager{
 		log:         log,
 		ontapClient: ontapClient,
 		seedClient:  seedClient,
@@ -73,7 +73,7 @@ func NewSvmManager(log logr.Logger, ontapClient *ontapv1.Ontap, seedClient clien
 }
 
 // CreateSVM creates an SVM and sets up network interfaces on a selected node
-func (m *SvnManager) CreateSVM(ctx context.Context, opts CreateSVMOptions) error {
+func (m *SvmManager) CreateSVM(ctx context.Context, opts CreateSVMOptions) error {
 	m.log.Info("Creating SVM with IPs", "name", opts.ProjectID, "managementLif", opts.SvmIpaddresses.ManagementLif, "dataLifs", opts.SvmIpaddresses.DataLifs)
 
 	// 1. Get a node for network interface placement and aggregate selection
@@ -180,7 +180,7 @@ func (m *SvnManager) CreateSVM(ctx context.Context, opts CreateSVMOptions) error
 
 // getAllNodesInCluster fetches the first node name found in the ONTAP cluster
 // Needs to be changed, waiting for Netapp answer
-func (m *SvnManager) getAllNodesInCluster(ctx context.Context) ([]string, error) {
+func (m *SvmManager) getAllNodesInCluster(ctx context.Context) ([]string, error) {
 	m.log.Info("Fetching first available node in cluster...")
 
 	var nodeUUIDs []string
@@ -217,7 +217,7 @@ func (m *SvnManager) getAllNodesInCluster(ctx context.Context) ([]string, error)
 }
 
 // createNetworkInterfaceForSvm creates a network interface for the given SVM
-func (m *SvnManager) createNetworkInterfaceForSvm(ctx context.Context, opts networkInterfaceOptions) error {
+func (m *SvmManager) createNetworkInterfaceForSvm(ctx context.Context, opts networkInterfaceOptions) error {
 
 	m.log.Info("Creating network interface", "svm", opts.svmName, "lifName", opts.lifName, "ip", opts.ipAddress, "node", opts.nodeUUID)
 
@@ -282,7 +282,7 @@ func (m *SvnManager) createNetworkInterfaceForSvm(ctx context.Context, opts netw
 }
 
 // Returns a svm by inputting the svmName, i.e. projectId
-func (m *SvnManager) GetSVMByName(ctx context.Context, svmName string) (*string, error) {
+func (m *SvmManager) GetSVMByName(ctx context.Context, svmName string) (*string, error) {
 
 	var svmUUID *string
 
@@ -333,7 +333,7 @@ func (m *SvnManager) GetSVMByName(ctx context.Context, svmName string) (*string,
 }
 
 // waitForSvmReady polls until the SVM exists and is in a "running" state.
-func (m *SvnManager) waitForSvmReady(ctx context.Context, svmName string) (string, error) {
+func (m *SvmManager) waitForSvmReady(ctx context.Context, svmName string) (string, error) {
 	m.log.Info("waiting for SVM to be ready", "svmName", svmName)
 
 	var uuid string

--- a/pkg/trident/svm.go
+++ b/pkg/trident/svm.go
@@ -308,7 +308,7 @@ func (m *SvmManager) GetSVMByName(ctx context.Context, svmName string) (*string,
 				// This can only happen on the first shoot of the project
 				// If this happens on the second shoot or n shoot, something is really broken
 				secretName := fmt.Sprintf("ontap-svm-%s-credentials", svmName)
-				err = m.seedClient.Get(ctx, client.ObjectKeyFromObject(&corev1.Secret{ObjectMeta: v1.ObjectMeta{Name: secretName, Namespace: "kube-system"}}), nil)
+				err = m.seedClient.Get(ctx, client.ObjectKeyFromObject(&corev1.Secret{ObjectMeta: v1.ObjectMeta{Name: secretName, Namespace: "kube-system"}}), &corev1.Secret{})
 				if err != nil {
 					if k8serrors.IsNotFound(err) {
 						m.log.Info("seed secret does not exist even tho svm exists, changing password of svm and creating seed secret")

--- a/pkg/trident/svm.go
+++ b/pkg/trident/svm.go
@@ -322,7 +322,10 @@ func (m *SvmManager) GetSVMByName(ctx context.Context, svmName string) (*string,
 		if err != nil {
 			if k8serrors.IsNotFound(err) {
 				m.log.Info("seed secret does not exist even tho svm exists, changing password of svm and creating seed secret")
-				m.CreateMissingSeedSecret(ctx, svmName, m.ontapClient)
+				err = m.CreateMissingSeedSecret(ctx, svmName, m.ontapClient)
+				if err != nil {
+					return nil, err
+				}
 			}
 			return nil, err
 		}

--- a/pkg/trident/svm.go
+++ b/pkg/trident/svm.go
@@ -24,8 +24,8 @@ import (
 )
 
 var (
-	// ErrNotFound is returned if the svm was not found
-	ErrNotFound = errors.New("NotFound")
+	// ErrSvmNotFound is returned if the svm was not found
+	ErrSvmNotFound = errors.New("NotFound")
 	// ErrAlreadyExists is returned when the entity already exists
 	ErrAlreadyExists = errors.New("AlreadyExists")
 
@@ -300,7 +300,7 @@ func (m *SvnManager) GetSVMByName(ctx context.Context, svmName string) (*string,
 
 	if len(svmGetOK.Payload.SvmResponseInlineRecords) == 0 {
 		m.log.Info("No SVMs found in the response")
-		return nil, ErrNotFound
+		return nil, ErrSvmNotFound
 	}
 
 	for _, svm := range svmGetOK.Payload.SvmResponseInlineRecords {
@@ -309,7 +309,7 @@ func (m *SvnManager) GetSVMByName(ctx context.Context, svmName string) (*string,
 				m.log.Info("Found SVM", "name", svmName, "uuid", *svm.UUID)
 				svmUUID = svm.UUID
 			}
-			return nil, ErrNotFound
+			return nil, ErrSvmNotFound
 		}
 	}
 
@@ -329,7 +329,7 @@ func (m *SvnManager) GetSVMByName(ctx context.Context, svmName string) (*string,
 	}
 
 	m.log.Info("SVM not found", "name", svmName)
-	return nil, ErrNotFound
+	return nil, ErrSvmNotFound
 }
 
 // waitForSvmReady polls until the SVM exists and is in a "running" state.
@@ -340,7 +340,7 @@ func (m *SvnManager) waitForSvmReady(ctx context.Context, svmName string) (strin
 	err := retry.Do(func() error {
 		svmUUID, err := m.GetSVMByName(ctx, svmName)
 		if err != nil {
-			if errors.Is(err, ErrNotFound) {
+			if errors.Is(err, ErrSvmNotFound) {
 				m.log.Info("SVM not found by name yet, retrying...", "svmName", svmName)
 				return err
 			}

--- a/pkg/trident/user.go
+++ b/pkg/trident/user.go
@@ -211,7 +211,7 @@ func (m *SvmManager) CreateMissingSeedSecret(ctx context.Context, svmName string
 	if err != nil {
 		var apiErr *runtime.APIError
 		if errors.As(err, &apiErr) {
-			if !(apiErr.Code == 200 && strings.Contains(apiErr.Error(), "unexpected success response")) {
+			if apiErr.Code != 200 || !strings.Contains(apiErr.Error(), "unexpected success response") {
 				return fmt.Errorf("unable to create password for project %s on ontap:%w", svmName, err)
 			}
 		}

--- a/pkg/trident/user.go
+++ b/pkg/trident/user.go
@@ -170,7 +170,7 @@ func (m *SvmManager) updateExistingUserPassword(ctx context.Context, username, s
 		return password, ErrSeedSecretMissing
 	}
 
-	// swallow unexpected success error, done by @mwenrich
+	// swallow unexpected success error
 	if strings.Contains(pwdErr.Error(), "unexpected success response") && strings.Contains(pwdErr.Error(), "status 200") {
 		m.log.Info("Password updated successfully (reported as error)", "username", username, "svm", svmName)
 		return password, ErrSeedSecretMissing

--- a/pkg/trident/user.go
+++ b/pkg/trident/user.go
@@ -211,9 +211,12 @@ func (m *SvmManager) CreateMissingSeedSecret(ctx context.Context, svmName string
 	if err != nil {
 		var apiErr *runtime.APIError
 		if errors.As(err, &apiErr) {
+			// swallow unexpected success error
 			if apiErr.Code != 200 || !strings.Contains(apiErr.Error(), "unexpected success response") {
 				return fmt.Errorf("unable to create password for project %s on ontap:%w", svmName, err)
 			}
+		} else {
+			return fmt.Errorf("unable to create password for project %s on ontap:%w", svmName, err)
 		}
 	}
 

--- a/pkg/trident/user.go
+++ b/pkg/trident/user.go
@@ -192,7 +192,6 @@ func buildSecret(secretName, userName, password, projectId string) *corev1.Secre
 
 func (m *SvmManager) CreateMissingSeedSecret(ctx context.Context, svmName string, ontapclient *ontapv1.Ontap) error {
 	// The ontap api doesn't have a way of getting password for users, therefore we update the password and create the seed secret with the updated password
-
 	password, err := generateSecurePassword()
 	if err != nil {
 		return err

--- a/pkg/trident/user.go
+++ b/pkg/trident/user.go
@@ -207,13 +207,13 @@ func (m *SvmManager) CreateMissingSeedSecret(ctx context.Context, svmName string
 	}
 	_, err = ontapclient.Security.AccountPasswordCreate(secparams, nil)
 	if err != nil {
-		return err
+		return fmt.Errorf("unable to create password for project %s on ontap:%w", svmName, err)
 	}
 
 	secretName := fmt.Sprintf(SecretNameFormat, svmName)
 	err = m.buildAndCreateSecretInSeed(ctx, secretName, defaultSVMUsername, password, svmName)
 	if err != nil {
-		return err
+		return fmt.Errorf("unable to create secret %s in seed %w", secretName, err)
 	}
 
 	return nil

--- a/pkg/trident/user.go
+++ b/pkg/trident/user.go
@@ -160,9 +160,9 @@ func (m *SvmManager) checkIfAccountExistsForSvm(ctx context.Context, svmName str
 }
 
 func generateSecurePassword() (string, error) {
-	// Generate a password that is 8 characters long with 2 digits, 2 symbols,
+	// Generate a password that is 8 characters long with 2 digits, 0 symbols,
 	// allowing upper and lower case letters, disallowing repeat characters.
-	res, err := password.Generate(8, 2, 2, false, false)
+	res, err := password.Generate(8, 2, 0, false, false)
 	if err != nil {
 		return "", fmt.Errorf("unable to create a random password:%w", err)
 	}
@@ -198,9 +198,13 @@ func (m *SvmManager) CreateMissingSeedSecret(ctx context.Context, svmName string
 	}
 
 	secparams := security.NewAccountPasswordCreateParamsWithContext(ctx)
-	*secparams.Info.Password = strfmt.Password(password)
-	secparams.Info.Owner.Name = &svmName
-	*secparams.Info.Name = defaultSVMUsername
+	secparams.Info = &models.AccountPassword{
+		Name:     pointer.Pointer(defaultSVMUsername),
+		Password: pointer.Pointer(strfmt.Password(password)),
+		Owner: &models.AccountPasswordInlineOwner{
+			Name: &svmName,
+		},
+	}
 	_, err = ontapclient.Security.AccountPasswordCreate(secparams, nil)
 	if err != nil {
 		return err

--- a/pkg/trident/user.go
+++ b/pkg/trident/user.go
@@ -51,7 +51,7 @@ type ontapUserOptions struct {
 }
 
 // CreateUserAndSecret creates an svm scoped account set to vsadmin role.
-func (m *SvnManager) CreateUserAndSecret(ctx context.Context, opts userAndSecretOptions) error {
+func (m *SvmManager) CreateUserAndSecret(ctx context.Context, opts userAndSecretOptions) error {
 	m.log.Info("Creating user for SVM", "svm", opts.projectID)
 	secretName := fmt.Sprintf(SecretNameFormat, opts.projectID)
 	// Create or update user with the vsadmin role
@@ -80,7 +80,7 @@ func (m *SvnManager) CreateUserAndSecret(ctx context.Context, opts userAndSecret
 }
 
 // createONTAPUserForSVM checks if the user exists on ONTAP first, then potentially creates it.
-func (m *SvnManager) createONTAPUserForSVM(ctx context.Context, opts ontapUserOptions) (string, error) {
+func (m *SvmManager) createONTAPUserForSVM(ctx context.Context, opts ontapUserOptions) (string, error) {
 
 	m.log.Info("Ensuring ONTAP user for SVM", "username", opts.username, "svm", opts.svmName)
 
@@ -136,7 +136,7 @@ func (m *SvnManager) createONTAPUserForSVM(ctx context.Context, opts ontapUserOp
 	return password, ErrSeedSecretMissing
 }
 
-func (m *SvnManager) checkIfAccountExistsForSvm(ctx context.Context, svmName string, kubeSeedSecret string) (string, error) {
+func (m *SvmManager) checkIfAccountExistsForSvm(ctx context.Context, svmName string, kubeSeedSecret string) (string, error) {
 	// Check if secret exists in the kube-system namespace in seed
 	secretName := fmt.Sprintf(SecretNameFormat, svmName)
 	existingSecret := &corev1.Secret{}
@@ -190,7 +190,7 @@ func buildSecret(secretName, userName, password, projectId string) *corev1.Secre
 	}
 }
 
-func (m *SvnManager) CreateMissingSeedSecret(ctx context.Context, svmName string, ontapclient *ontapv1.Ontap) error {
+func (m *SvmManager) CreateMissingSeedSecret(ctx context.Context, svmName string, ontapclient *ontapv1.Ontap) error {
 	// The ontap api doesn't have a way of getting password for users, therefore we update the password and create the seed secret with the updated password
 
 	password, err := generateSecurePassword()
@@ -216,7 +216,7 @@ func (m *SvnManager) CreateMissingSeedSecret(ctx context.Context, svmName string
 	return nil
 }
 
-func (m *SvnManager) buildAndCreateSecretInSeed(ctx context.Context, secretName, userName, password, projectId string) error {
+func (m *SvmManager) buildAndCreateSecretInSeed(ctx context.Context, secretName, userName, password, projectId string) error {
 	tridentSecret := buildSecret(secretName, defaultSVMUsername, password, projectId)
 	// make this use of managedResource aswell, otherwise seed secret can be deleted
 	if err := m.seedClient.Create(ctx, tridentSecret); err != nil {


### PR DESCRIPTION
## Description

The ontap api doesn't have an endpoint that returns the password for a user, therefore if the problem expressed in the issue description happens, we update the svm user password and create the seed secret.

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
You maybe want to attach the triage label if you want it to be discussed in the next planning meeting. It might be useful to attend the meeting if you want to emphasize it.

If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
