### PR TITLE
set fsType to ext4 in StorageClass

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,7 @@ parameters:
   csi.storage.k8s.io/node-stage-secret-namespace: ${pvc.namespace}
   backendType: "ontap-san"
   provisioningType: "thin"
+  fsType: "ext4"
 allowVolumeExpansion: true
 
 ```

--- a/charts/trident/resources/backends/storageclass.yaml
+++ b/charts/trident/resources/backends/storageclass.yaml
@@ -8,6 +8,7 @@ parameters:
   backendType: "ontap-san"
   provisioningType: "thin"
   selector: "luks=false"
+  fsType: "ext4"
 allowVolumeExpansion: true
 
 ---
@@ -20,6 +21,7 @@ parameters:
   backendType: "ontap-san"
   provisioningType: "thin"
   selector: "luks=true"
+  fsType: "ext4"
   csi.storage.k8s.io/node-stage-secret-name: storage-encryption-key
   csi.storage.k8s.io/node-stage-secret-namespace: ${pvc.namespace}
 allowVolumeExpansion: true


### PR DESCRIPTION
## Description

set fsType to ext4 in StorageClass

From https://github.com/NetAppDocs/trident/blob/main/trident-reference/objects.adoc 

Kubernetes will apply the fsGroup value only if:
- fsType is set in the storage class.
- The PVC access mode is RWO.

### Required Actions

```ACTIONS_REQUIRED
After deploying this version, all ONTAP storage classes in all affected shoots must be deleted, since storage classes are immutable.
```
