### PR TITLE
configure ontap-csi-node daemonset as system-critical

### DIFF
--- a/charts/trident/resources/trident-init/bundle.yaml
+++ b/charts/trident/resources/trident-init/bundle.yaml
@@ -519,6 +519,8 @@ kind: DaemonSet
 metadata:
   name: ontap-csi-node
   namespace: kube-system
+labels:
+  node.gardener.cloud/critical-component: "true"
 spec:
   selector:
     matchLabels:
@@ -533,6 +535,8 @@ spec:
       labels:
         app: ontap-csi-plugin
         role: node
+        gardener.cloud/role: system-component
+        node.gardener.cloud/critical-component: "true"
     spec:
       priorityClassName: system-node-critical
       serviceAccount: trident-operator
@@ -561,3 +565,10 @@ spec:
         - name: modules-dir
           hostPath:
             path: /lib/modules
+      tolerations:
+        - effect: NoSchedule
+          operator: Exists
+        - effect: NoExecute
+          operator: Exists
+        - key: CriticalAddonsOnly
+          operator: Exists


### PR DESCRIPTION
## Description

ontap-csi-node should run as soon as possible, so the nvme-module is loaded when the trident-node-linux pod starts.
