### PR TITLE
Update storageclass to fix the expansion of encrypted volumes

### DIFF
--- a/charts/trident/resources/backends/storageclass.yaml
+++ b/charts/trident/resources/backends/storageclass.yaml
@@ -24,6 +24,8 @@ parameters:
   provisioningType: "thin"
   selector: "luks=true"
   fsType: "ext4"
+  csi.storage.k8s.io/node-expand-secret-name: storage-encryption-key
+  csi.storage.k8s.io/node-expand-secret-namespace: ${pvc.namespace}
   csi.storage.k8s.io/node-stage-secret-name: storage-encryption-key
   csi.storage.k8s.io/node-stage-secret-namespace: ${pvc.namespace}
 allowVolumeExpansion: true


### PR DESCRIPTION
## Description

Currently, `allowVolumeExpansion` in the `ontap-encrypted` storage class is set to `true`, but the [required parameters](https://docs.netapp.com/us-en/trident/trident-reco/security-luks.html#enable-volume-expansion) are not set.

As a result, the expansion of encrypted volumes fails:

```
failed to expand pvc with Expander.NodeExpand failed to expand the volume rpc error: code = InvalidArgument desc = cannot expand LUKS encrypted volume; no passphrase provided
```

However, when adding the described parameters to the storage class, it works:

```
MountVolume.NodeExpandVolume succeeded for volume "pvc-39886ac5-8322-4c7a-8db7-4439f28fc84d"
```