### PR TITLE
Make svm consider aggregate idempotency

### DIFF
--- a/pkg/trident/svm.go
+++ b/pkg/trident/svm.go
@@ -327,6 +327,82 @@ func (m *SvmManager) createNetworkInterfaceForSvm(ctx context.Context, ontapClie
 	return nil
 }
 
+// validateAndEnsureAggregates ensures the SVM has all available cluster aggregates assigned.
+// When new aggregates are added to the cluster, this will update the SVM to include them.
+func (m *SvmManager) validateAndEnsureAggregates(ctx context.Context, ontapClient *ontapv1.Ontap, svmUUID, svmName string) error {
+	// Get all aggregates available on the cluster
+	aggrParams := storage.NewAggregateCollectionGetParamsWithContext(ctx)
+	aggrResult, err := ontapClient.Storage.AggregateCollectionGet(aggrParams, nil)
+	if err != nil {
+		return fmt.Errorf("failed to get cluster aggregates: %w", err)
+	}
+
+	clusterAggregates := make(map[string]bool)
+	for _, aggr := range aggrResult.Payload.AggregateResponseInlineRecords {
+		if aggr.UUID != nil {
+			clusterAggregates[*aggr.UUID] = true
+		}
+	}
+
+	// Get the SVM's currently assigned aggregates
+	getParams := s_vm.NewSvmGetParamsWithContext(ctx)
+	getParams.SetUUID(svmUUID)
+	getParams.Fields = []string{"aggregates"}
+
+	svmInfo, err := ontapClient.SVM.SvmGet(getParams, nil)
+	if err != nil {
+		return fmt.Errorf("failed to get SVM aggregates: %w", err)
+	}
+
+	svmAggregates := make(map[string]bool)
+	if svmInfo.Payload != nil {
+		for _, aggr := range svmInfo.Payload.SvmInlineAggregates {
+			if aggr.UUID != nil {
+				svmAggregates[*aggr.UUID] = true
+			}
+		}
+	}
+
+	// Check if there are new aggregates not yet assigned to the SVM
+	var missing bool
+	for uuid := range clusterAggregates {
+		if !svmAggregates[uuid] {
+			missing = true
+			m.log.Info("Found aggregate not assigned to SVM", "svmName", svmName, "aggregateUUID", uuid)
+			break
+		}
+	}
+
+	if !missing {
+		m.log.Info("All cluster aggregates already assigned to SVM", "svmName", svmName, "count", len(clusterAggregates))
+		return nil
+	}
+
+	// Build the full aggregate list and update the SVM
+	var aggrArrayItem []*models.SvmInlineAggregatesInlineArrayItem
+	for uuid := range clusterAggregates {
+		u := uuid
+		aggrArrayItem = append(aggrArrayItem, &models.SvmInlineAggregatesInlineArrayItem{
+			UUID: &u,
+		})
+	}
+
+	m.log.Info("Updating SVM with all cluster aggregates", "svmName", svmName, "aggregateCount", len(aggrArrayItem))
+
+	modifyParams := s_vm.NewSvmModifyParamsWithContext(ctx)
+	modifyParams.SetUUID(svmUUID)
+	modifyParams.SetInfo(&models.Svm{
+		SvmInlineAggregates: aggrArrayItem,
+	})
+
+	if _, _, err := ontapClient.SVM.SvmModify(modifyParams, nil); err != nil {
+		return fmt.Errorf("failed to update SVM %s aggregates: %w", svmName, err)
+	}
+
+	m.log.Info("Successfully updated SVM aggregates", "svmName", svmName)
+	return nil
+}
+
 // validateAndEnsureCompleteSVMState validates all components of an SVM and creates missing parts
 func (m *SvmManager) validateAndEnsureCompleteSVMState(ctx context.Context, activeClient *ontapv1.Ontap, svmUUID, svmName string, opts CreateSVMOptions) error {
 	m.log.Info("Validating complete SVM state", "svmName", svmName, "uuid", svmUUID)
@@ -336,18 +412,23 @@ func (m *SvmManager) validateAndEnsureCompleteSVMState(ctx context.Context, acti
 		return err
 	}
 
-	// 2. Get cluster nodes for LIF creation (if needed)
+	// 2. Ensure all cluster aggregates are assigned to the SVM
+	if err := m.validateAndEnsureAggregates(ctx, activeClient, svmUUID, svmName); err != nil {
+		return err
+	}
+
+	// 3. Get cluster nodes for LIF creation (if needed)
 	nodesUUIDs, err := m.getAllNodesInCluster(ctx, activeClient)
 	if err != nil {
 		return fmt.Errorf("failed to get cluster nodes for SVM validation: %w", err)
 	}
 
-	// 3. Validate and ensure data LIFs exist
+	// 4. Validate and ensure data LIFs exist
 	if err := m.validateAndEnsureDataLIFs(ctx, activeClient, svmUUID, svmName, opts.SvmIpaddresses.DataLifs, nodesUUIDs); err != nil {
 		return err
 	}
 
-	// 4. Validate and ensure management LIF exists
+	// 5. Validate and ensure management LIF exists
 	if err := m.validateAndEnsureManagementLIF(ctx, activeClient, svmUUID, svmName, opts.SvmIpaddresses.ManagementLif, nodesUUIDs[0]); err != nil {
 		return err
 	}

--- a/pkg/trident/svm_test.go
+++ b/pkg/trident/svm_test.go
@@ -532,3 +532,124 @@ func TestValidateAndEnsureManagementLIF(t *testing.T) {
 		mc.networking.AssertCalled(t, "NetworkIPInterfacesCreate", mock.Anything, mock.Anything)
 	})
 }
+
+func TestValidateAndEnsureAggregates(t *testing.T) {
+	ctx := context.Background()
+	m := NewSvmManager(logr.Discard(), nil, nil)
+
+	t.Run("no-op when all aggregates already assigned", func(t *testing.T) {
+		mc := newMockOntapClient()
+
+		// Cluster has 2 aggregates
+		mc.storage.On("AggregateCollectionGet", mock.Anything, mock.Anything).
+			Return(&storage.AggregateCollectionGetOK{Payload: &models.AggregateResponse{
+				AggregateResponseInlineRecords: []*models.Aggregate{
+					{Name: new("aggr1"), UUID: new("uuid-1")},
+					{Name: new("aggr2"), UUID: new("uuid-2")},
+				},
+			}}, nil)
+
+		// SVM already has both aggregates
+		mc.svm.On("SvmGet", mock.Anything, mock.Anything).Return(&s_vm.SvmGetOK{
+			Payload: &models.Svm{
+				SvmInlineAggregates: []*models.SvmInlineAggregatesInlineArrayItem{
+					{UUID: new("uuid-1")},
+					{UUID: new("uuid-2")},
+				},
+			},
+		}, nil)
+
+		err := m.validateAndEnsureAggregates(ctx, mc.client, "svm-uuid", "svm-name")
+		require.NoError(t, err)
+		mc.svm.AssertNotCalled(t, "SvmModify", mock.Anything, mock.Anything)
+	})
+
+	t.Run("updates SVM when new aggregate is available", func(t *testing.T) {
+		mc := newMockOntapClient()
+
+		// Cluster has 3 aggregates (one new)
+		mc.storage.On("AggregateCollectionGet", mock.Anything, mock.Anything).
+			Return(&storage.AggregateCollectionGetOK{Payload: &models.AggregateResponse{
+				AggregateResponseInlineRecords: []*models.Aggregate{
+					{Name: new("aggr1"), UUID: new("uuid-1")},
+					{Name: new("aggr2"), UUID: new("uuid-2")},
+					{Name: new("aggr3"), UUID: new("uuid-3")},
+				},
+			}}, nil)
+
+		// SVM only has 2 aggregates
+		mc.svm.On("SvmGet", mock.Anything, mock.Anything).Return(&s_vm.SvmGetOK{
+			Payload: &models.Svm{
+				SvmInlineAggregates: []*models.SvmInlineAggregatesInlineArrayItem{
+					{UUID: new("uuid-1")},
+					{UUID: new("uuid-2")},
+				},
+			},
+		}, nil)
+
+		mc.svm.On("SvmModify", mock.Anything, mock.Anything).
+			Return(&s_vm.SvmModifyOK{}, nil, nil)
+
+		err := m.validateAndEnsureAggregates(ctx, mc.client, "svm-uuid", "svm-name")
+		require.NoError(t, err)
+		mc.svm.AssertCalled(t, "SvmModify", mock.Anything, mock.Anything)
+
+		// Verify the modify call contains all 3 aggregates
+		call := mc.svm.Calls[len(mc.svm.Calls)-1]
+		modifyParams := call.Arguments[0].(*s_vm.SvmModifyParams)
+		assert.Len(t, modifyParams.Info.SvmInlineAggregates, 3)
+	})
+
+	t.Run("updates SVM when it has no aggregates assigned", func(t *testing.T) {
+		mc := newMockOntapClient()
+
+		mc.storage.On("AggregateCollectionGet", mock.Anything, mock.Anything).
+			Return(&storage.AggregateCollectionGetOK{Payload: &models.AggregateResponse{
+				AggregateResponseInlineRecords: []*models.Aggregate{
+					{Name: new("aggr1"), UUID: new("uuid-1")},
+				},
+			}}, nil)
+
+		// SVM has no aggregates
+		mc.svm.On("SvmGet", mock.Anything, mock.Anything).Return(&s_vm.SvmGetOK{
+			Payload: &models.Svm{
+				SvmInlineAggregates: nil,
+			},
+		}, nil)
+
+		mc.svm.On("SvmModify", mock.Anything, mock.Anything).
+			Return(&s_vm.SvmModifyOK{}, nil, nil)
+
+		err := m.validateAndEnsureAggregates(ctx, mc.client, "svm-uuid", "svm-name")
+		require.NoError(t, err)
+		mc.svm.AssertCalled(t, "SvmModify", mock.Anything, mock.Anything)
+	})
+
+	t.Run("error on aggregate collection get failure", func(t *testing.T) {
+		mc := newMockOntapClient()
+		mc.storage.On("AggregateCollectionGet", mock.Anything, mock.Anything).
+			Return(nil, fmt.Errorf("storage unavailable"))
+
+		err := m.validateAndEnsureAggregates(ctx, mc.client, "svm-uuid", "svm-name")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "storage unavailable")
+	})
+
+	t.Run("error on svm get failure", func(t *testing.T) {
+		mc := newMockOntapClient()
+
+		mc.storage.On("AggregateCollectionGet", mock.Anything, mock.Anything).
+			Return(&storage.AggregateCollectionGetOK{Payload: &models.AggregateResponse{
+				AggregateResponseInlineRecords: []*models.Aggregate{
+					{Name: new("aggr1"), UUID: new("uuid-1")},
+				},
+			}}, nil)
+
+		mc.svm.On("SvmGet", mock.Anything, mock.Anything).
+			Return(nil, fmt.Errorf("svm unreachable"))
+
+		err := m.validateAndEnsureAggregates(ctx, mc.client, "svm-uuid", "svm-name")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "svm unreachable")
+	})
+}


### PR DESCRIPTION
## Description

Inside the new partition we will split up the existing aggregates into smaller ones, svms need to check for all existing svms and be idempotent to update their aggreagates to include the newly created ones.

